### PR TITLE
Implements #16: Add terminal GUI calculator

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc",
     "start": "ts-node src/calculator.ts",
+    "start:gui": "ts-node src/calculator.ts --gui",
     "test": "jest --config jest.config.cjs",
     "test:unit": "jest --config jest.config.cjs --selectProjects unit",
     "test:integration": "jest --config jest.config.cjs --selectProjects integration"
@@ -34,6 +35,9 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "bignumber.js": "^9.3.0"
+    "@types/blessed": "^0.1.25",
+    "bignumber.js": "^9.3.0",
+    "blessed": "^0.1.81",
+    "blessed-contrib": "^4.11.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@types/blessed':
+        specifier: ^0.1.25
+        version: 0.1.25
       bignumber.js:
         specifier: ^9.3.0
         version: 9.3.0
+      blessed:
+        specifier: ^0.1.81
+        version: 0.1.81
+      blessed-contrib:
+        specifier: ^4.11.0
+        version: 4.11.0
     devDependencies:
       '@types/inquirer':
         specifier: '8'
@@ -209,6 +218,10 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
+
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
@@ -341,6 +354,9 @@ packages:
   '@types/babel__traverse@7.20.7':
     resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
 
+  '@types/blessed@0.1.25':
+    resolution: {integrity: sha512-kQsjBgtsbJLmG6CJA+Z6Nujj+tq1fcSE3UIowbDvzQI4wWmoTV7djUDhSo5lDjgwpIN0oRvks0SA5mMdKE5eFg==}
+
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
@@ -374,6 +390,9 @@ packages:
   '@types/yargs@17.0.33':
     resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
 
+  abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
   acorn-walk@8.3.4:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
     engines: {node: '>=0.4.0'}
@@ -387,9 +406,21 @@ packages:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
 
+  ansi-escapes@6.2.1:
+    resolution: {integrity: sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==}
+    engines: {node: '>=14.16'}
+
+  ansi-regex@2.1.1:
+    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
+    engines: {node: '>=0.10.0'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+
+  ansi-styles@2.2.1:
+    resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
+    engines: {node: '>=0.10.0'}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -398,6 +429,12 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  ansi-term@0.0.2:
+    resolution: {integrity: sha512-jLnGE+n8uAjksTJxiWZf/kcUmXq+cRWSl550B9NmQ8YiqaTM+lILcSe5dHdp8QkJPhaOghDjnMKwyYSMjosgAA==}
+
+  ansicolors@0.3.2:
+    resolution: {integrity: sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==}
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -449,6 +486,14 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  blessed-contrib@4.11.0:
+    resolution: {integrity: sha512-P00Xji3xPp53+FdU9f74WpvnOAn/SS0CKLy4vLAf5Ps7FGDOTY711ruJPZb3/7dpFuP+4i7f4a/ZTZdLlKG9WA==}
+
+  blessed@0.1.81:
+    resolution: {integrity: sha512-LoF5gae+hlmfORcG1M5+5XZi4LBmvlXTzwJWzUlPryN/SJdSflZvROM2TwkT0GMpq7oqT48NRd4GS7BiVBc5OQ==}
+    engines: {node: '>= 0.8.0'}
+    hasBin: true
+
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
@@ -458,6 +503,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  bresenham@0.0.3:
+    resolution: {integrity: sha512-wbMxoJJM1p3+6G7xEFXYNCJ30h2qkwmVxebkbwIl4OcnWtno5R3UT9VuYLfStlVNAQCmRjkGwjPFdfaPd4iNXw==}
 
   browserslist@4.24.5:
     resolution: {integrity: sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==}
@@ -477,6 +525,10 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  buffers@0.1.1:
+    resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
+    engines: {node: '>=0.2.0'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -492,9 +544,21 @@ packages:
   caniuse-lite@1.0.30001718:
     resolution: {integrity: sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==}
 
+  cardinal@2.1.1:
+    resolution: {integrity: sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==}
+    hasBin: true
+
+  chalk@1.1.3:
+    resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
+    engines: {node: '>=0.10.0'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chalk@5.4.1:
+    resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -502,6 +566,9 @@ packages:
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  charm@0.1.2:
+    resolution: {integrity: sha512-syedaZ9cPe7r3hoQA9twWYKu5AIyCswN5+szkmPBe9ccdLrj4bYaCnLVPTLd2kgVRc7+zoX4tyPgRnFKCj5YjQ==}
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
@@ -517,6 +584,10 @@ packages:
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
 
   cli-width@3.0.0:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
@@ -549,6 +620,9 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
   create-jest@29.7.0:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
@@ -598,6 +672,12 @@ packages:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
 
+  drawille-blessed-contrib@1.0.0:
+    resolution: {integrity: sha512-WnHMgf5en/hVOsFhxLI8ZX0qTJmerOsVjIMQmn4cR1eI8nLGu+L7w5ENbul+lZ6w827A3JakCuernES5xbHLzQ==}
+
+  drawille-canvas-blessed-contrib@0.1.3:
+    resolution: {integrity: sha512-bdDvVJOxlrEoPLifGDPaxIzFh3cD7QH05ePoQ4fwnqfi08ZSxzEhOUpI5Z0/SQMlWgcCQOEtuw0zrwezacXglw==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -632,6 +712,9 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  event-stream@0.9.8:
+    resolution: {integrity: sha512-o5h0Mp1bkoR6B0i7pTCAzRy+VzdsRWH997KQD4Psb0EOPoKEIiaRx/EsOdUl7p1Ktjw7aIWvweI/OY1R9XrlUg==}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -697,6 +780,9 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
+  gl-matrix@2.8.1:
+    resolution: {integrity: sha512-0YCjVpE3pS5XWlN3J4X7AiAx65+nqAI54LndtVFnQZB6G/FVLkZH8y8V6R3cIoOQR4pUdfwQGd1iwyoXHJ4Qfw==}
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -708,6 +794,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  has-ansi@2.0.0:
+    resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==}
+    engines: {node: '>=0.10.0'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -715,6 +805,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  here@0.0.2:
+    resolution: {integrity: sha512-U7VYImCTcPoY27TSmzoiFsmWLEqQFaYNdpsPb9K0dXJhE6kufUqycaz51oR09CW85dDU9iWyy7At8M+p7hb3NQ==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -780,6 +873,9 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  isarray@0.0.1:
+    resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1000,6 +1096,27 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  map-canvas@0.1.5:
+    resolution: {integrity: sha512-f7M3sOuL9+up0NCOZbb1rQpWDLZwR/ftCiNbyscjl9LUUEwrRaoumH4sz6swgs58lF21DQ0hsYOCw5C6Zz7hbg==}
+
+  marked-terminal@5.2.0:
+    resolution: {integrity: sha512-Piv6yNwAQXGFjZSaiNljyNFw7jKDdGrw70FSbtxEyldLsyeuV5ZHm/1wW++kWbrOF1VPnUgYOhB2oLL0ZpnekA==}
+    engines: {node: '>=14.13.1 || >=16.0.0'}
+    peerDependencies:
+      marked: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+
+  marked@4.3.0:
+    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
+    engines: {node: '>= 12'}
+    hasBin: true
+
+  memory-streams@0.1.3:
+    resolution: {integrity: sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==}
+
+  memorystream@0.3.1:
+    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
+    engines: {node: '>= 0.10.0'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -1027,11 +1144,18 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  node-emoji@1.11.0:
+    resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
+
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
+  nopt@2.1.2:
+    resolution: {integrity: sha512-x8vXm7BZ2jE1Txrxh/hO74HTuYZQEbo8edoRcANgdZ4+PCV+pbjd/xdummkmjjC7LU5EjPzlu8zEq/oxWylnKA==}
+    hasBin: true
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -1047,6 +1171,12 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  optimist@0.2.8:
+    resolution: {integrity: sha512-Wy7E3cQDpqsTIFyW7m22hSevyTLxw850ahYv7FWsw4G6MIKVTZ8NSA95KBrQ95a4SMsMr1UGUUnwEFKhVaSzIg==}
+
+  optimist@0.3.7:
+    resolution: {integrity: sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==}
 
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
@@ -1098,6 +1228,11 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picture-tuber@1.0.2:
+    resolution: {integrity: sha512-49/xq+wzbwDeI32aPvwQJldM8pr7dKDRuR76IjztrkmiCkAQDaWFJzkmfVqCHmt/iFoPFhHmI9L0oKhthrTOQw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -1105,6 +1240,9 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  png-js@0.1.1:
+    resolution: {integrity: sha512-NTtk2SyfjBm+xYl2/VZJBhFnTQ4kU5qWC7VC4/iGbrgiU4FuB4xC+74erxADYJIqZICOR1HCvRA7EBHkpjTg9g==}
 
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
@@ -1120,9 +1258,15 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  readable-stream@1.0.34:
+    resolution: {integrity: sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  redeyed@2.1.1:
+    resolution: {integrity: sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -1162,6 +1306,9 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  sax@1.4.1:
+    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -1196,6 +1343,11 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  sparkline@0.1.2:
+    resolution: {integrity: sha512-t//aVOiWt9fi/e22ea1vXVWBDX+gp18y+Ch9sKqmHl828bRfvP2VtfTJVEcgWFBQHd0yDPNQRiHdqzCvbcYSDA==}
+    engines: {node: '>= 0.8.0'}
+    hasBin: true
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -1211,8 +1363,15 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string_decoder@0.10.31:
+    resolution: {integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@3.0.1:
+    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
+    engines: {node: '>=0.10.0'}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1230,6 +1389,10 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  supports-color@2.0.0:
+    resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
+    engines: {node: '>=0.8.0'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -1238,9 +1401,16 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  supports-hyperlinks@2.3.0:
+    resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
+    engines: {node: '>=8'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  term-canvas@0.0.5:
+    resolution: {integrity: sha512-eZ3rIWi5yLnKiUcsW8P79fKyooaLmyLWAGqBhFspqMxRNUiB4GmHHk5AzQ4LxvFbJILaXqQZLwbbATLOhCFwkw==}
 
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -1348,6 +1518,10 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  wordwrap@0.0.3:
+    resolution: {integrity: sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==}
+    engines: {node: '>=0.4.0'}
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -1362,6 +1536,18 @@ packages:
   write-file-atomic@4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  x256@0.0.2:
+    resolution: {integrity: sha512-ZsIH+sheoF8YG9YG+QKEEIdtqpHRA9FYuD7MqhfyB1kayXU43RUNBFSxBEnF8ywSUxdg+8no4+bPr5qLbyxKgA==}
+    engines: {node: '>=0.4.0'}
+
+  xml2js@0.4.23:
+    resolution: {integrity: sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -1579,6 +1765,9 @@ snapshots:
       '@babel/helper-validator-identifier': 7.27.1
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@colors/colors@1.5.0':
+    optional: true
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -1817,6 +2006,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.27.1
 
+  '@types/blessed@0.1.25':
+    dependencies:
+      '@types/node': 20.17.48
+
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 20.17.48
@@ -1857,6 +2050,8 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
+  abbrev@1.1.1: {}
+
   acorn-walk@8.3.4:
     dependencies:
       acorn: 8.14.1
@@ -1867,13 +2062,25 @@ snapshots:
     dependencies:
       type-fest: 0.21.3
 
+  ansi-escapes@6.2.1: {}
+
+  ansi-regex@2.1.1: {}
+
   ansi-regex@5.0.1: {}
+
+  ansi-styles@2.2.1: {}
 
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
+
+  ansi-term@0.0.2:
+    dependencies:
+      x256: 0.0.2
+
+  ansicolors@0.3.2: {}
 
   anymatch@3.1.3:
     dependencies:
@@ -1955,6 +2162,25 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  blessed-contrib@4.11.0:
+    dependencies:
+      ansi-term: 0.0.2
+      chalk: 1.1.3
+      drawille-canvas-blessed-contrib: 0.1.3
+      lodash: 4.17.21
+      map-canvas: 0.1.5
+      marked: 4.3.0
+      marked-terminal: 5.2.0(marked@4.3.0)
+      memory-streams: 0.1.3
+      memorystream: 0.3.1
+      picture-tuber: 1.0.2
+      sparkline: 0.1.2
+      strip-ansi: 3.0.1
+      term-canvas: 0.0.5
+      x256: 0.0.2
+
+  blessed@0.1.81: {}
+
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
@@ -1967,6 +2193,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  bresenham@0.0.3: {}
 
   browserslist@4.24.5:
     dependencies:
@@ -1990,6 +2218,8 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  buffers@0.1.1: {}
+
   callsites@3.1.0: {}
 
   camelcase@5.3.1: {}
@@ -1998,14 +2228,31 @@ snapshots:
 
   caniuse-lite@1.0.30001718: {}
 
+  cardinal@2.1.1:
+    dependencies:
+      ansicolors: 0.3.2
+      redeyed: 2.1.1
+
+  chalk@1.1.3:
+    dependencies:
+      ansi-styles: 2.2.1
+      escape-string-regexp: 1.0.5
+      has-ansi: 2.0.0
+      strip-ansi: 3.0.1
+      supports-color: 2.0.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.4.1: {}
+
   char-regex@1.0.2: {}
 
   chardet@0.7.0: {}
+
+  charm@0.1.2: {}
 
   ci-info@3.9.0: {}
 
@@ -2016,6 +2263,12 @@ snapshots:
       restore-cursor: 3.1.0
 
   cli-spinners@2.9.2: {}
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
 
   cli-width@3.0.0: {}
 
@@ -2040,6 +2293,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  core-util-is@1.0.3: {}
 
   create-jest@29.7.0(@types/node@20.17.48)(ts-node@10.9.2(@types/node@20.17.48)(typescript@5.8.3)):
     dependencies:
@@ -2082,6 +2337,16 @@ snapshots:
 
   diff@4.0.2: {}
 
+  drawille-blessed-contrib@1.0.0: {}
+
+  drawille-canvas-blessed-contrib@0.1.3:
+    dependencies:
+      ansi-term: 0.0.2
+      bresenham: 0.0.3
+      drawille-blessed-contrib: 1.0.0
+      gl-matrix: 2.8.1
+      x256: 0.0.2
+
   ejs@3.1.10:
     dependencies:
       jake: 10.9.2
@@ -2103,6 +2368,10 @@ snapshots:
   escape-string-regexp@2.0.0: {}
 
   esprima@4.0.1: {}
+
+  event-stream@0.9.8:
+    dependencies:
+      optimist: 0.2.8
 
   execa@5.1.1:
     dependencies:
@@ -2170,6 +2439,8 @@ snapshots:
 
   get-stream@6.0.1: {}
 
+  gl-matrix@2.8.1: {}
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -2183,11 +2454,17 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  has-ansi@2.0.0:
+    dependencies:
+      ansi-regex: 2.1.1
+
   has-flag@4.0.0: {}
 
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  here@0.0.2: {}
 
   html-escaper@2.0.2: {}
 
@@ -2248,6 +2525,8 @@ snapshots:
   is-stream@2.0.1: {}
 
   is-unicode-supported@0.1.0: {}
+
+  isarray@0.0.1: {}
 
   isexe@2.0.0: {}
 
@@ -2654,6 +2933,29 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  map-canvas@0.1.5:
+    dependencies:
+      drawille-canvas-blessed-contrib: 0.1.3
+      xml2js: 0.4.23
+
+  marked-terminal@5.2.0(marked@4.3.0):
+    dependencies:
+      ansi-escapes: 6.2.1
+      cardinal: 2.1.1
+      chalk: 5.4.1
+      cli-table3: 0.6.5
+      marked: 4.3.0
+      node-emoji: 1.11.0
+      supports-hyperlinks: 2.3.0
+
+  marked@4.3.0: {}
+
+  memory-streams@0.1.3:
+    dependencies:
+      readable-stream: 1.0.34
+
+  memorystream@0.3.1: {}
+
   merge-stream@2.0.0: {}
 
   micromatch@4.0.8:
@@ -2677,9 +2979,17 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  node-emoji@1.11.0:
+    dependencies:
+      lodash: 4.17.21
+
   node-int64@0.4.0: {}
 
   node-releases@2.0.19: {}
+
+  nopt@2.1.2:
+    dependencies:
+      abbrev: 1.1.1
 
   normalize-path@3.0.0: {}
 
@@ -2694,6 +3004,14 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  optimist@0.2.8:
+    dependencies:
+      wordwrap: 0.0.3
+
+  optimist@0.3.7:
+    dependencies:
+      wordwrap: 0.0.3
 
   ora@5.4.1:
     dependencies:
@@ -2742,11 +3060,22 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picture-tuber@1.0.2:
+    dependencies:
+      buffers: 0.1.1
+      charm: 0.1.2
+      event-stream: 0.9.8
+      optimist: 0.3.7
+      png-js: 0.1.1
+      x256: 0.0.2
+
   pirates@4.0.7: {}
 
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  png-js@0.1.1: {}
 
   pretty-format@29.7.0:
     dependencies:
@@ -2763,11 +3092,22 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  readable-stream@1.0.34:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 0.0.1
+      string_decoder: 0.10.31
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  redeyed@2.1.1:
+    dependencies:
+      esprima: 4.0.1
 
   require-directory@2.1.1: {}
 
@@ -2800,6 +3140,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sax@1.4.1: {}
+
   semver@6.3.1: {}
 
   semver@7.7.2: {}
@@ -2823,6 +3165,11 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  sparkline@0.1.2:
+    dependencies:
+      here: 0.0.2
+      nopt: 2.1.2
+
   sprintf-js@1.0.3: {}
 
   stack-utils@2.0.6:
@@ -2840,9 +3187,15 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string_decoder@0.10.31: {}
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  strip-ansi@3.0.1:
+    dependencies:
+      ansi-regex: 2.1.1
 
   strip-ansi@6.0.1:
     dependencies:
@@ -2854,6 +3207,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  supports-color@2.0.0: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -2862,7 +3217,14 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-hyperlinks@2.3.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  term-canvas@0.0.5: {}
 
   test-exclude@6.0.0:
     dependencies:
@@ -2960,6 +3322,8 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  wordwrap@0.0.3: {}
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -2978,6 +3342,15 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
+
+  x256@0.0.2: {}
+
+  xml2js@0.4.23:
+    dependencies:
+      sax: 1.4.1
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
 
   y18n@5.0.8: {}
 

--- a/src/calculator.ts
+++ b/src/calculator.ts
@@ -6,6 +6,7 @@ import { multiply } from "./commands/multiply";
 import { divide } from "./commands/divide";
 import { power } from "./commands/power";
 import { startInteractiveMode } from "./interactiveMode";
+import { startCalculatorUI } from "./calculatorUI";
 
 /**
  * Main calculator function that processes command line arguments
@@ -14,6 +15,12 @@ import { startInteractiveMode } from "./interactiveMode";
 function main(): void {
   // Get command line arguments (skip the first two which are node and script path)
   const args = process.argv.slice(2);
+
+  // If --gui flag is passed, start the GUI mode
+  if (args.includes('--gui')) {
+    startCalculatorUI();
+    return;
+  }
 
   // If no arguments are provided, start the interactive mode
   if (args.length === 0) {
@@ -24,6 +31,7 @@ function main(): void {
   // Check if we have exactly two arguments
   if (args.length !== 2) {
     console.error("Usage: node calculator.js <number1> <number2>");
+    console.error("       node calculator.js --gui (for terminal GUI)");
     process.exit(1);
   }
 

--- a/src/calculatorUI.ts
+++ b/src/calculatorUI.ts
@@ -367,6 +367,12 @@ export function startCalculatorUI(): void {
     updateDisplay();
   };
 
+  // Log function for debugging
+  const logToStatus = (msg: string) => {
+    statusText = msg;
+    updateDisplay();
+  };
+
   // Create calculator buttons using regular boxes instead of buttons
   const createButton = (label: string, top: number, left: number, width: number, height: number, callback: () => void, color: string = 'white', bg: string = 'blue') => {
     const button = blessed.box({
@@ -552,9 +558,9 @@ export function startCalculatorUI(): void {
   createButton('^', row + (buttonHeight + 1) * 4, 1, buttonWidth, buttonHeight, () => {
     handleOperator('^');
   }, 'white', 'magenta');
-  
-  // Equals button - highlight this with a different style
-  createButton('=', row + (buttonHeight + 1) * 4, col, buttonWidth, buttonHeight, () => {
+
+  // Equals button - highlight this with a different style and make it larger
+  createButton('=', row, col + buttonWidth + 1, buttonWidth, buttonHeight, () => {
     handleEquals();
   }, 'black', 'green');
   

--- a/src/calculatorUI.ts
+++ b/src/calculatorUI.ts
@@ -508,6 +508,10 @@ export function startCalculatorUI(): void {
   let row = 7;
   let col = 1;
 
+  // Save the position below 9 for equals button
+  const nineButtonRow = row + (buttonHeight + 1) * 2; // After 2 rows (1-3, 4-6, 7-9)
+  const nineButtonCol = col + (buttonWidth + 1) * 2; // After 2 columns (7, 8, 9)
+
   // Numbers 1-9
   for (let i = 1; i <= 9; i++) {
     const digit = String(i);
@@ -534,6 +538,11 @@ export function startCalculatorUI(): void {
     }
   });
 
+  // Equals button - place below 9 and to the right of decimal point
+  createButton('=', nineButtonRow, nineButtonCol, buttonWidth, buttonHeight, () => {
+    handleEquals();
+  }, 'black', 'green');
+
   // Operation buttons
   row = 7;
   col = 28;
@@ -558,11 +567,6 @@ export function startCalculatorUI(): void {
   createButton('^', row + (buttonHeight + 1) * 4, 1, buttonWidth, buttonHeight, () => {
     handleOperator('^');
   }, 'white', 'magenta');
-
-  // Equals button - highlight this with a different style and make it larger
-  createButton('=', row, col + buttonWidth + 1, buttonWidth, buttonHeight, () => {
-    handleEquals();
-  }, 'black', 'green');
   
   // Clear button
   createButton('C', row + (buttonHeight + 1) * 4, 1 + buttonWidth + 1, buttonWidth, buttonHeight, () => {

--- a/src/calculatorUI.ts
+++ b/src/calculatorUI.ts
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+
+import * as blessed from 'blessed';
+import { sum } from "./commands/sum";
+import { subtract } from "./commands/subtract";
+import { multiply } from "./commands/multiply";
+import { divide } from "./commands/divide";
+import { power } from "./commands/power";
+
+/**
+ * Memory functionality for the calculator
+ */
+class CalculatorMemory {
+  private memoryValue: number = 0;
+
+  store(value: number): void {
+    this.memoryValue = value;
+  }
+
+  recall(): number {
+    return this.memoryValue;
+  }
+
+  clear(): void {
+    this.memoryValue = 0;
+  }
+}
+
+/**
+ * Terminal-based GUI Calculator
+ */
+export function startCalculatorUI(): void {
+  // Create screen
+  const screen = blessed.screen({
+    smartCSR: true,
+    title: 'Terminal Calculator'
+  });
+
+  // Help user exit
+  screen.key(['escape', 'q', 'C-c'], () => {
+    return process.exit(0);
+  });
+
+  // Create calculator memory
+  const memory = new CalculatorMemory();
+
+  // Calculator state
+  let displayValue = '0';
+  let firstOperand: number | null = null;
+  let waitingForSecondOperand = false;
+  let operator: string | null = null;
+
+  // Main container
+  const container = blessed.box({
+    top: 'center',
+    left: 'center',
+    width: 40,
+    height: 30,
+    border: {
+      type: 'line'
+    },
+    style: {
+      border: {
+        fg: 'blue'
+      }
+    }
+  });
+
+  // Title
+  const title = blessed.text({
+    top: 0,
+    left: 'center',
+    content: '📟 Terminal Calculator 📟',
+    style: {
+      fg: 'white',
+      bold: true
+    }
+  });
+
+  // Display
+  const display = blessed.box({
+    top: 2,
+    right: 1,
+    width: 38,
+    height: 3,
+    content: displayValue,
+    align: 'right',
+    valign: 'middle',
+    border: {
+      type: 'line'
+    },
+    style: {
+      fg: 'green',
+      bg: 'black',
+      border: {
+        fg: 'green'
+      }
+    }
+  });
+
+  // Update the display
+  const updateDisplay = () => {
+    display.setContent(displayValue);
+    screen.render();
+  };
+
+  // Process digit input
+  const inputDigit = (digit: string) => {
+    if (waitingForSecondOperand) {
+      displayValue = digit;
+      waitingForSecondOperand = false;
+    } else {
+      displayValue = displayValue === '0' ? digit : displayValue + digit;
+    }
+    updateDisplay();
+  };
+
+  // Process operation
+  const handleOperator = (nextOperator: string) => {
+    const inputValue = parseFloat(displayValue);
+    
+    if (firstOperand === null) {
+      firstOperand = inputValue;
+    } else if (operator) {
+      const result = performCalculation(operator);
+      displayValue = String(result);
+      firstOperand = result;
+    }
+    
+    waitingForSecondOperand = true;
+    operator = nextOperator;
+    updateDisplay();
+  };
+
+  // Perform calculation
+  const performCalculation = (op: string): number => {
+    if (firstOperand === null) return 0;
+    
+    const secondOperand = parseFloat(displayValue);
+    let result = 0;
+    
+    switch (op) {
+      case '+':
+        result = sum(firstOperand, secondOperand);
+        break;
+      case '-':
+        result = subtract(firstOperand, secondOperand);
+        break;
+      case '*':
+        result = multiply(firstOperand, secondOperand);
+        break;
+      case '/':
+        try {
+          result = divide(firstOperand, secondOperand);
+        } catch (e) {
+          displayValue = 'Error';
+          firstOperand = null;
+          waitingForSecondOperand = false;
+          operator = null;
+          updateDisplay();
+          return 0;
+        }
+        break;
+      case '^':
+        result = power(firstOperand, secondOperand);
+        break;
+    }
+    
+    return result;
+  };
+
+  // Handle equals button
+  const handleEquals = () => {
+    if (!operator || firstOperand === null) return;
+    
+    const result = performCalculation(operator);
+    displayValue = String(result);
+    firstOperand = null;
+    waitingForSecondOperand = false;
+    operator = null;
+    updateDisplay();
+  };
+
+  // Clear the calculator
+  const clearCalculator = () => {
+    displayValue = '0';
+    firstOperand = null;
+    waitingForSecondOperand = false;
+    operator = null;
+    updateDisplay();
+  };
+
+  // Memory functions
+  const memoryStore = () => {
+    memory.store(parseFloat(displayValue));
+  };
+
+  const memoryRecall = () => {
+    displayValue = String(memory.recall());
+    updateDisplay();
+  };
+
+  const memoryClear = () => {
+    memory.clear();
+  };
+
+  // Create calculator buttons
+  const createButton = (label: string, top: number, left: number, width: number, height: number, callback: () => void, color: string = 'white', bg: string = 'blue') => {
+    const button = blessed.button({
+      top,
+      left,
+      width,
+      height,
+      content: label,
+      align: 'center',
+      valign: 'middle',
+      border: {
+        type: 'line'
+      },
+      style: {
+        fg: color,
+        bg,
+        border: {
+          fg: color
+        },
+        focus: {
+          bg: 'green'
+        },
+        hover: {
+          bg: 'green'
+        }
+      }
+    });
+    
+    button.on('press', callback);
+    container.append(button);
+    return button;
+  };
+
+  // Number buttons
+  const buttonWidth = 8;
+  const buttonHeight = 3;
+  let row = 6;
+  let col = 1;
+
+  // Numbers 1-9
+  for (let i = 1; i <= 9; i++) {
+    createButton(String(i), row, col, buttonWidth, buttonHeight, () => inputDigit(String(i)));
+    col += buttonWidth + 1;
+    if (i % 3 === 0) {
+      row += buttonHeight + 1;
+      col = 1;
+    }
+  }
+
+  // Zero button
+  createButton('0', row, col, buttonWidth, buttonHeight, () => inputDigit('0'));
+
+  // Decimal button
+  createButton('.', row, col + buttonWidth + 1, buttonWidth, buttonHeight, () => {
+    if (!displayValue.includes('.')) {
+      displayValue += '.';
+      updateDisplay();
+    }
+  });
+
+  // Operation buttons
+  row = 6;
+  col = 28;
+  
+  createButton('+', row, col, buttonWidth, buttonHeight, () => handleOperator('+'), 'white', 'red');
+  createButton('-', row + buttonHeight + 1, col, buttonWidth, buttonHeight, () => handleOperator('-'), 'white', 'red');
+  createButton('×', row + (buttonHeight + 1) * 2, col, buttonWidth, buttonHeight, () => handleOperator('*'), 'white', 'red');
+  createButton('÷', row + (buttonHeight + 1) * 3, col, buttonWidth, buttonHeight, () => handleOperator('/'), 'white', 'red');
+  
+  // Power button
+  createButton('^', row + (buttonHeight + 1) * 4, 1, buttonWidth, buttonHeight, () => handleOperator('^'), 'white', 'magenta');
+  
+  // Equals button
+  createButton('=', row + (buttonHeight + 1) * 4, col, buttonWidth, buttonHeight, handleEquals, 'white', 'green');
+  
+  // Clear button
+  createButton('C', row + (buttonHeight + 1) * 4, 1 + buttonWidth + 1, buttonWidth, buttonHeight, clearCalculator, 'black', 'yellow');
+  
+  // Memory buttons
+  createButton('M+', row + (buttonHeight + 1) * 4, 1 + (buttonWidth + 1) * 2, buttonWidth, buttonHeight, memoryStore, 'white', 'cyan');
+  createButton('MR', row + (buttonHeight + 1) * 4, 1 + (buttonWidth + 1) * 3, buttonWidth, buttonHeight, memoryRecall, 'white', 'cyan');
+  createButton('MC', row + (buttonHeight + 1) * 4 - buttonHeight - 1, 1 + (buttonWidth + 1) * 3, buttonWidth, buttonHeight, memoryClear, 'white', 'cyan');
+
+  // Add components to screen
+  container.append(title);
+  container.append(display);
+  screen.append(container);
+
+  // Focus on container
+  container.focus();
+
+  // Render the screen
+  screen.render();
+}
+
+// If this file is run directly
+if (require.main === module) {
+  startCalculatorUI();
+} 

--- a/src/calculatorUI.ts
+++ b/src/calculatorUI.ts
@@ -508,9 +508,6 @@ export function startCalculatorUI(): void {
   let row = 7;
   let col = 1;
 
-  // Save the position below 9 for equals button
-  const nineButtonRow = row + (buttonHeight + 1) * 2; // After 2 rows (1-3, 4-6, 7-9)
-  const nineButtonCol = col + (buttonWidth + 1) * 2; // After 2 columns (7, 8, 9)
 
   // Numbers 1-9
   for (let i = 1; i <= 9; i++) {
@@ -538,10 +535,9 @@ export function startCalculatorUI(): void {
     }
   });
 
-  // Equals button - place below 9 and to the right of decimal point
-  createButton('=', nineButtonRow, nineButtonCol, buttonWidth, buttonHeight, () => {
+  createButton('=', row, col + (buttonWidth + 1) * 2, buttonWidth, buttonHeight, () => {
     handleEquals();
-  }, 'black', 'green');
+  }, 'white', 'yellow');
 
   // Operation buttons
   row = 7;
@@ -568,12 +564,11 @@ export function startCalculatorUI(): void {
     handleOperator('^');
   }, 'white', 'magenta');
   
-  // Clear button
-  createButton('C', row + (buttonHeight + 1) * 4, 1 + buttonWidth + 1, buttonWidth, buttonHeight, () => {
-    clearCalculator();
-  }, 'black', 'yellow');
-  
   // Memory buttons
+  createButton('MC', row + (buttonHeight + 1) * 4, 1 + (buttonWidth + 1), buttonWidth, buttonHeight, () => {
+    memoryClear();
+  }, 'white', 'cyan');
+
   createButton('M+', row + (buttonHeight + 1) * 4, 1 + (buttonWidth + 1) * 2, buttonWidth, buttonHeight, () => {
     memoryStore();
   }, 'white', 'cyan');
@@ -582,9 +577,11 @@ export function startCalculatorUI(): void {
     memoryRecall();
   }, 'white', 'cyan');
   
-  createButton('MC', row + (buttonHeight + 1) * 4 - buttonHeight - 1, 1 + (buttonWidth + 1) * 3, buttonWidth, buttonHeight, () => {
-    memoryClear();
-  }, 'white', 'cyan');
+  // Clear button
+  row = row + (buttonHeight + 1) * 5 - 1;
+  createButton('C', row, 1 + buttonWidth + 1, buttonWidth * 2 + 1, buttonHeight, () => {
+    clearCalculator();
+    }, 'white', 'yellow');
 
   // Help button
   createButton('?', 0, 1, 3, 3, () => {

--- a/src/calculatorUI.ts
+++ b/src/calculatorUI.ts
@@ -51,7 +51,6 @@ export function startCalculatorUI(): void {
   let waitingForSecondOperand = false;
   let operator: string | null = null;
   let statusText = 'Ready';
-  let keyboardModeActive = false;
 
   // Main container
   const container = blessed.box({
@@ -113,26 +112,10 @@ export function startCalculatorUI(): void {
     }
   });
 
-  // Keyboard mode indicator
-  const keyboardIndicator = blessed.box({
-    top: 5,
-    left: 1,
-    width: 15,
-    height: 1,
-    content: '⌨️ OFF',
-    align: 'left',
-    tags: true,
-    style: {
-      fg: 'gray',
-      bold: true
-    }
-  });
-
   // Update the display
   const updateDisplay = () => {
     display.setContent(displayValue);
     status.setContent(statusText);
-    keyboardIndicator.setContent(keyboardModeActive ? '{bold}{green-fg}⌨️ ON{/}' : '{gray-fg}⌨️ OFF{/}');
     screen.render();
   };
 
@@ -271,15 +254,13 @@ export function startCalculatorUI(): void {
   };
 
   // Create calculator buttons using regular boxes instead of buttons
-  const createButton = (label: string, top: number, left: number, width: number, height: number, callback: () => void, color: string = 'white', bg: string = 'blue', keyChar: string | null = null) => {
-    const buttonLabel = keyChar ? `${label} (${keyChar})` : label;
-    
+  const createButton = (label: string, top: number, left: number, width: number, height: number, callback: () => void, color: string = 'white', bg: string = 'blue') => {
     const button = blessed.box({
       top,
       left,
       width,
       height,
-      content: buttonLabel,
+      content: label,
       align: 'center',
       valign: 'middle',
       tags: true,
@@ -300,11 +281,6 @@ export function startCalculatorUI(): void {
       mouse: true
     });
     
-    // Store a reference to the button if it has a key shortcut
-    if (keyChar) {
-      buttonRefs[keyChar] = { element: button, originalBg: bg };
-    }
-    
     // Handle mouse events
     button.on('click', () => {
       callback();
@@ -315,100 +291,21 @@ export function startCalculatorUI(): void {
     return button;
   };
 
-  // Store references to buttons for keyboard highlighting
-  const buttonRefs: Record<string, { element: blessed.Widgets.BoxElement, originalBg: string }> = {};
-
-  // Highlight button when key is pressed
-  const highlightButton = (key: string) => {
-    if (buttonRefs[key]) {
-      const { element, originalBg } = buttonRefs[key];
-      // Flash the button
-      element.style.bg = 'white';
-      element.style.fg = 'black';
-      screen.render();
-      
-      // Reset after a short delay
-      setTimeout(() => {
-        element.style.bg = originalBg;
-        element.style.fg = originalBg === 'yellow' || originalBg === 'green' ? 'black' : 'white';
-        screen.render();
-      }, 150);
-    }
-  };
-
-  // Toggle keyboard mode
-  const toggleKeyboardMode = () => {
-    keyboardModeActive = !keyboardModeActive;
-    statusText = keyboardModeActive ? 'Keyboard mode activated' : 'Keyboard mode deactivated';
-    updateDisplay();
-  };
-
   // Add keyboard support for number keys, operations, and equals
   screen.key(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'], (ch, key) => {
     inputDigit(key.name);
-    highlightButton(key.name);
-  });
-
-  screen.key('.', () => {
-    if (!displayValue.includes('.')) {
-      displayValue += '.';
-      updateDisplay();
-    }
-    highlightButton('.');
   });
   
-  screen.key('+', () => {
-    handleOperator('+');
-    highlightButton('+');
-  });
-  
-  screen.key('-', () => {
-    handleOperator('-');
-    highlightButton('-');
-  });
-  
-  screen.key('*', () => {
-    handleOperator('*');
-    highlightButton('*');
-  });
-  
-  screen.key('/', () => {
-    handleOperator('/');
-    highlightButton('/');
-  });
-  
-  screen.key('^', () => {
-    handleOperator('^');
-    highlightButton('^');
-  });
-  
-  screen.key(['=', 'return', 'enter'], () => {
-    handleEquals();
-    highlightButton('=');
-  });
-  
-  screen.key('c', () => {
-    clearCalculator();
-    highlightButton('c');
-  });
-  
-  screen.key('m', () => {
-    memoryStore();
-    highlightButton('m');
-  });
-  
-  screen.key('r', () => {
-    memoryRecall();
-    highlightButton('r');
-  });
-  
-  screen.key('x', () => {
-    memoryClear();
-    highlightButton('x');
-  });
-
-  // Toggle keyboard mode with F1 key
-  screen.key('f1', toggleKeyboardMode);
+  screen.key(['+'], () => handleOperator('+'));
+  screen.key(['-'], () => handleOperator('-'));
+  screen.key(['*'], () => handleOperator('*'));
+  screen.key(['/'], () => handleOperator('/'));
+  screen.key(['^'], () => handleOperator('^'));
+  screen.key(['=', 'return'], () => handleEquals());
+  screen.key(['c'], () => clearCalculator());
+  screen.key(['m'], () => memoryStore());
+  screen.key(['r'], () => memoryRecall());
+  screen.key(['x'], () => memoryClear());
 
   // Number buttons
   const buttonWidth = 8;
@@ -421,7 +318,7 @@ export function startCalculatorUI(): void {
     const digit = String(i);
     createButton(digit, row, col, buttonWidth, buttonHeight, () => {
       inputDigit(digit);
-    }, 'white', 'blue', digit);
+    });
     col += buttonWidth + 1;
     if (i % 3 === 0) {
       row += buttonHeight + 1;
@@ -432,7 +329,7 @@ export function startCalculatorUI(): void {
   // Zero button
   createButton('0', row, col, buttonWidth, buttonHeight, () => {
     inputDigit('0');
-  }, 'white', 'blue', '0');
+  });
 
   // Decimal button
   createButton('.', row, col + buttonWidth + 1, buttonWidth, buttonHeight, () => {
@@ -440,7 +337,7 @@ export function startCalculatorUI(): void {
       displayValue += '.';
       updateDisplay();
     }
-  }, 'white', 'blue', '.');
+  });
 
   // Operation buttons
   row = 7;
@@ -448,65 +345,59 @@ export function startCalculatorUI(): void {
   
   createButton('+', row, col, buttonWidth, buttonHeight, () => {
     handleOperator('+');
-  }, 'white', 'red', '+');
+  }, 'white', 'red');
   
   createButton('-', row + buttonHeight + 1, col, buttonWidth, buttonHeight, () => {
     handleOperator('-');
-  }, 'white', 'red', '-');
+  }, 'white', 'red');
   
   createButton('×', row + (buttonHeight + 1) * 2, col, buttonWidth, buttonHeight, () => {
     handleOperator('*');
-  }, 'white', 'red', '*');
+  }, 'white', 'red');
   
   createButton('÷', row + (buttonHeight + 1) * 3, col, buttonWidth, buttonHeight, () => {
     handleOperator('/');
-  }, 'white', 'red', '/');
+  }, 'white', 'red');
   
   // Power button
   createButton('^', row + (buttonHeight + 1) * 4, 1, buttonWidth, buttonHeight, () => {
     handleOperator('^');
-  }, 'white', 'magenta', '^');
+  }, 'white', 'magenta');
   
   // Equals button - highlight this with a different style
   createButton('=', row + (buttonHeight + 1) * 4, col, buttonWidth, buttonHeight, () => {
     handleEquals();
-  }, 'black', 'green', '=');
+  }, 'black', 'green');
   
   // Clear button
   createButton('C', row + (buttonHeight + 1) * 4, 1 + buttonWidth + 1, buttonWidth, buttonHeight, () => {
     clearCalculator();
-  }, 'black', 'yellow', 'c');
+  }, 'black', 'yellow');
   
   // Memory buttons
   createButton('M+', row + (buttonHeight + 1) * 4, 1 + (buttonWidth + 1) * 2, buttonWidth, buttonHeight, () => {
     memoryStore();
-  }, 'white', 'cyan', 'm');
+  }, 'white', 'cyan');
   
   createButton('MR', row + (buttonHeight + 1) * 4, 1 + (buttonWidth + 1) * 3, buttonWidth, buttonHeight, () => {
     memoryRecall();
-  }, 'white', 'cyan', 'r');
+  }, 'white', 'cyan');
   
   createButton('MC', row + (buttonHeight + 1) * 4 - buttonHeight - 1, 1 + (buttonWidth + 1) * 3, buttonWidth, buttonHeight, () => {
     memoryClear();
-  }, 'white', 'cyan', 'x');
-
-  // Keyboard mode toggle
-  createButton('F1: ⌨️', 1, 2, 10, 3, () => {
-    toggleKeyboardMode();
-  }, 'black', 'white');
+  }, 'white', 'cyan');
 
   // Add components to screen
   container.append(title);
   container.append(display);
   container.append(status);
-  container.append(keyboardIndicator);
   screen.append(container);
 
   // Add instruction text
   const instructions = blessed.text({
     bottom: 0,
     left: 'center',
-    content: 'Mouse: Click buttons | Keyboard: Numbers, +, -, *, /, ^, =, Enter, c, m, r, x | F1: Toggle keyboard | ESC/q to exit',
+    content: 'Mouse: Click buttons | Keyboard: Numbers, +, -, *, /, ^, =, Enter, c, m, r, x | ESC/q to exit',
     style: {
       fg: 'white',
     }

--- a/src/interactiveMode.ts
+++ b/src/interactiveMode.ts
@@ -5,6 +5,7 @@ import { subtract } from "./commands/subtract";
 import { multiply } from "./commands/multiply";
 import { divide } from "./commands/divide";
 import { power } from "./commands/power";
+import { startCalculatorUI } from "./calculatorUI";
 
 // Define operation type for better type safety
 type Operation = {
@@ -42,6 +43,7 @@ async function showMainMenu(): Promise<void> {
     { name: '✖️ Multiplication', value: 'multiply', function: multiply },
     { name: '➗ Division', value: 'divide', function: divide },
     { name: '🔢 Power', value: 'power', function: power },
+    { name: '🖥️ Switch to GUI Mode', value: 'gui', function: () => 0 },
     { name: '🚪 Exit', value: 'exit', function: () => 0 }
   ];
   
@@ -58,6 +60,12 @@ async function showMainMenu(): Promise<void> {
     
     if (operation.value === 'exit') {
       console.log(chalk.green('\nThank you for using the Interactive Calculator! Goodbye! 👋\n'));
+      return;
+    }
+
+    if (operation.value === 'gui') {
+      console.log(chalk.cyan('\nSwitching to GUI mode...\n'));
+      startCalculatorUI();
       return;
     }
     


### PR DESCRIPTION
This PR adds a terminal GUI calculator using the blessed library. It includes:

- A new calculator UI with a calculator-like interface
- Support for all operations (addition, subtraction, multiplication, division, power)
- Memory buttons (M+, MR, MC) for storing and retrieving values
- A Clear button to reset the calculator
- Integration with the existing calculator functionality

The GUI can be accessed either via the '--gui' flag when running the calculator or from the interactive mode using a new menu option.

Resolves #16 
